### PR TITLE
Upgrade libde265, libheif, and ImageMagick

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,23 +4,23 @@ ARG DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && apt-get install -y \
   libheif-dev
 
-RUN curl -L https://github.com/strukturag/libde265/releases/download/v1.0.3/libde265-1.0.3.tar.gz | tar zx \
-  && cd libde265-1.0.3 \
+RUN curl -L https://github.com/strukturag/libde265/releases/download/v1.0.5/libde265-1.0.5.tar.gz | tar zx \
+  && cd libde265-1.0.5 \
   && ./autogen.sh \
   && ./configure \
   && make \
   && make install
 
-RUN curl -L https://github.com/strukturag/libheif/releases/download/v1.3.2/libheif-1.3.2.tar.gz | tar zx \
-  && cd libheif-1.3.2 \
+RUN curl -L https://github.com/strukturag/libheif/releases/download/v1.6.2/libheif-1.6.2.tar.gz | tar zx \
+  && cd libheif-1.6.2 \
   && ./autogen.sh \
   && ./configure \
   && make \
   && make install
 
 RUN cd /usr/src/ \
-  && wget https://imagemagick.org/download/releases/ImageMagick-7.0.8-53.tar.gz \
-  && tar xf ImageMagick-7.0.8-53.tar.gz \
+  && wget https://imagemagick.org/download/releases/ImageMagick-7.0.10-9.tar.gz \
+  && tar xf ImageMagick-7.0.10-9.tar.gz \
   && cd ImageMagick-7* \
   && ./configure --with-heic=yes --prefix=/usr/src/imagemagick \
   && make \

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM heroku/heroku:18-build
 ARG DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update && apt-get install -y \
-  libheif-dev
+  libheif-dev libjpeg-dev libpng-dev libtiff-dev libgif-dev
 
 RUN curl -L https://github.com/strukturag/libde265/releases/download/v1.0.5/libde265-1.0.5.tar.gz | tar zx \
   && cd libde265-1.0.5 \
@@ -33,7 +33,8 @@ RUN cd /usr/src/ \
   && make install
 
 RUN cp /usr/local/lib/libde265.so.0 /usr/src/imagemagick/lib \
-  && cp /usr/local/lib/libheif.so.1 /usr/src/imagemagick/lib
+  && cp /usr/local/lib/libheif.so.1 /usr/src/imagemagick/lib \
+  && cp /usr/local/lib/libwebp.so /usr/src/imagemagick/lib
 
 # clean the build area ready for packaging
 RUN cd /usr/src/imagemagick \

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,6 +18,12 @@ RUN curl -L https://github.com/strukturag/libheif/releases/download/v1.6.2/libhe
   && make \
   && make install
 
+RUN curl -L http://storage.googleapis.com/downloads.webmproject.org/releases/webp/libwebp-1.1.0.tar.gz | tar zx \
+  && cd libwebp-1.1.0 \
+  && ./configure \
+  && make \
+  && make install
+
 RUN cd /usr/src/ \
   && wget https://imagemagick.org/download/releases/ImageMagick-7.0.10-9.tar.gz \
   && tar xf ImageMagick-7.0.10-9.tar.gz \

--- a/Dockerfile
+++ b/Dockerfile
@@ -34,7 +34,7 @@ RUN cd /usr/src/ \
 
 RUN cp /usr/local/lib/libde265.so.0 /usr/src/imagemagick/lib \
   && cp /usr/local/lib/libheif.so.1 /usr/src/imagemagick/lib \
-  && cp /usr/local/lib/libwebp.so /usr/src/imagemagick/lib
+  && cp /usr/local/lib/libwebp.so.7 /usr/src/imagemagick/lib
 
 # clean the build area ready for packaging
 RUN cd /usr/src/imagemagick \


### PR DESCRIPTION
Makes the following upgrades:

1. libde265 from 1.0.3 to 1.0.5
2. libheif from 1.3.2 to 1.6.2
3. ImageMagick from 7.0.8-53 to 7.0.10-9